### PR TITLE
Add (again) HEAD

### DIFF
--- a/noah.rb
+++ b/noah.rb
@@ -2,8 +2,8 @@ class Noah < Formula
   desc "Darwin subsystem for Linux (Bash on macOS)"
   homepage "https://github.com/linux-noah/noah"
   url "https://github.com/linux-noah/noah/archive/0.5.1.tar.gz"
-  version "0.5.1"
   sha256 "452c00b1baeafca73e6566b552c9d63dc304504be95296f6568274cd74073660"
+  head "https://github.com/linux-noah/noah.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
`HEAD` has been accidentally removed, so this PR will add one again.

This PR also remove redundant version declaration.
Homebrew can automatically set version from filename of archive, as long as the filename contains a sane version string.